### PR TITLE
fix: update URL building to use params for query parameters in BlazeService

### DIFF
--- a/service/blaze_service.py
+++ b/service/blaze_service.py
@@ -386,19 +386,21 @@ class BlazeService:
         :param patient_id: Identifier of the sample donor
         :return: FHIR resource id
         """
-        return glom(self._session.get(url=self._blaze_url + "/Patient?identifier=" + patient_id,
+        return glom(self._session.get(url=f"{self._blaze_url}/Patient",
+                                      params={"identifier": patient_id},
                                       verify=False).json(), "**.resource.id")[0]
 
     def patient_has_condition(self, patient_identifier: str, icd_10_code: str) -> bool:
         """Checks if patient already has a condition with specific ICD-10 code (use a dot format)."""
         try:
-            patient_fhir_id = glom(self._session.get(url=f"{self._blaze_url}/Patient?identifier={patient_identifier}",
+            patient_fhir_id = glom(self._session.get(url=f"{self._blaze_url}/Patient",
+                                                     params={"identifier": patient_identifier},
                                                      verify=False).json(), "**.resource.id")[0]
         except IndexError:
             raise PatientNotFoundError
-        search_url = f"{self._blaze_url}/Condition?patient={patient_fhir_id}" \
-                     f"&code={icd_10_code}"
-        return self._session.get(search_url, verify=False).json().get("total") > 0
+        return self._session.get(f"{self._blaze_url}/Condition",
+                                 params={"patient": patient_fhir_id, "code": icd_10_code},
+                                 verify=False).json().get("total") > 0
 
     def __check_sample_and_patient_presence(self, sample) -> tuple[bool, bool]:
         """Check if sample and patient are present in Blaze store."""
@@ -546,7 +548,9 @@ class BlazeService:
     def __get_organization_fhir_id(self, organization_identifier: str):
         organization_fhir_id = \
             glom(self._session.get(
-                url=self._blaze_url + f"/Organization?identifier={organization_identifier}", verify=False)
+                url=f"{self._blaze_url}/Organization",
+                params={"identifier": organization_identifier},
+                verify=False)
                  .json(), "**.resource.id")[0]
         return organization_fhir_id
 
@@ -557,7 +561,8 @@ class BlazeService:
         :return: The number of resources in the Blaze store.
         """
         try:
-            return self._session.get(url=self._blaze_url + f"/{resource_type.capitalize()}?_summary=count",
+            return self._session.get(url=f"{self._blaze_url}/{resource_type.capitalize()}",
+                                     params={"_summary": "count"},
                                      verify=False).json().get("total")
         except requests.exceptions.ConnectionError:
             logger.error("Cannot connect to blaze!")
@@ -572,8 +577,8 @@ class BlazeService:
         :param resource_type: Type of FHIR resource to delete.
         :return: Status code of the http request.
         """
-        response = self._session.get(url=self._blaze_url + f"/{resource_type.capitalize()}"
-                                                           f"?{search_param}={param_value}",
+        response = self._session.get(url=f"{self._blaze_url}/{resource_type.capitalize()}",
+                                     params={search_param: param_value},
                                      verify=False)
         list_of_full_urls: list[str] = glom(response.json(), "**.fullUrl")
         if response.status_code == 404 or len(list_of_full_urls) == 0:
@@ -606,11 +611,11 @@ class BlazeService:
             logger.info(f"Donor with FHIR id {donor_fhir_id} is not present in the blaze store.")
         donor_entry = self.__create_delete_bundle_entry("Patient", donor_fhir_id)
         entries.append(donor_entry)
-        conditions_response = self._session.get(url=self._blaze_url + f"/Condition"
-                                                                      f"?subject=Patient/{donor_fhir_id}",
+        conditions_response = self._session.get(url=f"{self._blaze_url}/Condition",
+                                                params={"subject": f"Patient/{donor_fhir_id}"},
                                                 verify=False)
-        samples_response = self._session.get(url=self._blaze_url + f"/Specimen"
-                                                                   f"?subject=Patient/{donor_fhir_id}",
+        samples_response = self._session.get(url=f"{self._blaze_url}/Specimen",
+                                             params={"subject": f"Patient/{donor_fhir_id}"},
                                              verify=False)
         for condition_json in conditions_response.json().get("entry", []):
             condition_resource = condition_json.get("resource", {})
@@ -656,6 +661,21 @@ class BlazeService:
         logger.info("Delete successful")
         return True
 
+    def get_resource_count_by_identifier(self, resource_type: str, identifier: str) -> int:
+        """
+        Returns the count of FHIR resources of a given type matching an identifier.
+        Uses params= so identifiers with reserved URL characters are encoded correctly.
+        :param resource_type: FHIR resource type (e.g. "Specimen", "Patient").
+        :param identifier: Business identifier value (may contain &, ?, =, /, spaces, etc.).
+        :return: Total count reported by Blaze, or 0 on error.
+        """
+        response = self._session.get(
+            url=f"{self._blaze_url}/{resource_type.capitalize()}",
+            params={"identifier": identifier, "_summary": "count"},
+            verify=False,
+        )
+        return response.json().get("total", 0)
+
     def is_resource_present_in_blaze(self, resource_type: str, identifier: str) -> bool:
         """
         Checks if a resource of specific type with a specific identifier is present in the Blaze store.
@@ -665,11 +685,7 @@ class BlazeService:
         :return: bool
         """
         try:
-            count = (self._session.get(
-                url=self._blaze_url + f"/{resource_type.capitalize()}?identifier={identifier}&_summary=count",
-                verify=False)
-                     .json()
-                     .get("total"))
+            count = self.get_resource_count_by_identifier(resource_type, identifier)
             logger.debug(f"Count of resource : {count} of type: {resource_type} with identifier :{identifier} ")
             return count > 0
         except TypeError:
@@ -779,7 +795,8 @@ class BlazeService:
         :param sample_identifier: Identifier of the sample.
         :return: FHIR resource ID of the sample."""
 
-        sample = self._session.get(url=self._blaze_url + f"/Specimen?identifier={sample_identifier}",
+        sample = self._session.get(url=f"{self._blaze_url}/Specimen",
+                                   params={"identifier": sample_identifier},
                                    verify=False).json()
         return glom(sample, "**.resource.id")[0]
 

--- a/test/unit/service/test_blaze_service_url_encoding.py
+++ b/test/unit/service/test_blaze_service_url_encoding.py
@@ -1,0 +1,186 @@
+"""
+Unit tests proving that FHIR search requests use proper URL parameter encoding
+(via requests params=) rather than manual string concatenation.
+
+Identifiers with reserved URL characters (&, ?, =, /, space) must be percent-encoded
+in the query string so that Blaze receives the correct identifier value.
+"""
+
+import unittest
+from unittest.mock import Mock, patch, call
+
+from service.blaze_service import BlazeService
+
+
+RESERVED_CHAR_IDENTIFIERS = [
+    "&:2022:118485",
+    "A&B",
+    "abc?x=1",
+    "a/b",
+    "space value",
+]
+
+
+def _make_service(mock_session):
+    with patch("service.blaze_service.requests.session") as mock_session_factory, \
+         patch("service.blaze_service.setup_logger"), \
+         patch("service.blaze_service.get_blaze_auth", return_value=("u", "p")), \
+         patch("service.blaze_service.get_metrics_for_service"):
+        mock_session_factory.return_value = mock_session
+        return BlazeService(
+            patient_service=Mock(),
+            condition_service=Mock(),
+            sample_service=Mock(),
+            blaze_url="http://blaze:8080/fhir",
+            sample_collection_repository=Mock(),
+        )
+
+
+class TestUrlEncodingIsResourcePresentInBlaze(unittest.TestCase):
+    """is_resource_present_in_blaze must pass identifier via params=, not string concat."""
+
+    def setUp(self):
+        self.mock_session = Mock()
+        self.service = _make_service(self.mock_session)
+
+        mock_response = Mock()
+        mock_response.json.return_value = {"total": 1}
+        self.mock_session.get.return_value = mock_response
+
+    def _assert_params_used(self, identifier: str, resource_type: str = "Specimen"):
+        self.mock_session.get.reset_mock()
+        result = self.service.is_resource_present_in_blaze(resource_type, identifier)
+
+        self.assertTrue(result)
+        self.mock_session.get.assert_called_once()
+        _, kwargs = self.mock_session.get.call_args
+        params = kwargs.get("params", {})
+        self.assertEqual(params.get("identifier"), identifier,
+                         f"identifier not passed via params= for {identifier!r}")
+        self.assertEqual(params.get("_summary"), "count")
+        url = kwargs.get("url", "")
+        self.assertNotIn(identifier, url,
+                         f"Raw identifier {identifier!r} found in URL — use params= instead")
+
+    def test_ampersand_prefix(self):
+        self._assert_params_used("&:2022:118485")
+
+    def test_ampersand_mid_value(self):
+        self._assert_params_used("A&B")
+
+    def test_question_mark_and_equals(self):
+        self._assert_params_used("abc?x=1")
+
+    def test_slash_in_value(self):
+        self._assert_params_used("a/b")
+
+    def test_space_in_value(self):
+        self._assert_params_used("space value")
+
+    def test_plain_identifier_still_works(self):
+        self._assert_params_used("plain-id-123")
+
+
+class TestUrlEncodingGetResourceCountByIdentifier(unittest.TestCase):
+    """get_resource_count_by_identifier must use params= and return the total."""
+
+    def setUp(self):
+        self.mock_session = Mock()
+        self.service = _make_service(self.mock_session)
+
+    def _setup_response(self, total: int):
+        mock_response = Mock()
+        mock_response.json.return_value = {"total": total}
+        self.mock_session.get.return_value = mock_response
+
+    def test_returns_correct_count(self):
+        self._setup_response(9)
+        count = self.service.get_resource_count_by_identifier("Specimen", "&:2022:118485")
+        self.assertEqual(count, 9)
+
+    def test_zero_total(self):
+        self._setup_response(0)
+        count = self.service.get_resource_count_by_identifier("Patient", "A&B")
+        self.assertEqual(count, 0)
+
+    def test_params_kwarg_used_for_all_reserved_identifiers(self):
+        self._setup_response(1)
+        for identifier in RESERVED_CHAR_IDENTIFIERS:
+            self.mock_session.get.reset_mock()
+            self.service.get_resource_count_by_identifier("Specimen", identifier)
+            _, kwargs = self.mock_session.get.call_args
+            params = kwargs.get("params", {})
+            self.assertEqual(params.get("identifier"), identifier,
+                             f"identifier not in params= for {identifier!r}")
+            url = kwargs.get("url", "")
+            self.assertNotIn(identifier, url,
+                             f"Raw {identifier!r} in URL — use params=")
+
+
+class TestUrlEncodingPatientHasCondition(unittest.TestCase):
+    """patient_has_condition must use params= for both Patient lookup and Condition search."""
+
+    def setUp(self):
+        self.mock_session = Mock()
+        self.service = _make_service(self.mock_session)
+
+    def test_patient_lookup_uses_params(self):
+        patient_response = Mock()
+        patient_response.json.return_value = {
+            "entry": [{"resource": {"id": "fhir-123"}}]
+        }
+        condition_response = Mock()
+        condition_response.json.return_value = {"total": 0}
+        self.mock_session.get.side_effect = [patient_response, condition_response]
+
+        self.service.patient_has_condition("A&B", "C50.9")
+
+        patient_call = self.mock_session.get.call_args_list[0]
+        _, pkwargs = patient_call
+        self.assertEqual(pkwargs.get("params", {}).get("identifier"), "A&B")
+        patient_url = pkwargs.get("url", "")
+        self.assertNotIn("A&B", patient_url)
+
+    def test_condition_search_uses_params(self):
+        patient_response = Mock()
+        patient_response.json.return_value = {
+            "entry": [{"resource": {"id": "fhir-456"}}]
+        }
+        condition_response = Mock()
+        condition_response.json.return_value = {"total": 1}
+        self.mock_session.get.side_effect = [patient_response, condition_response]
+
+        result = self.service.patient_has_condition("plain-patient", "C50.9")
+
+        self.assertTrue(result)
+        condition_call = self.mock_session.get.call_args_list[1]
+        _, ckwargs = condition_call
+        params = ckwargs.get("params", {})
+        self.assertIn("patient", params)
+        self.assertIn("code", params)
+        self.assertEqual(params["code"], "C50.9")
+
+
+class TestUrlEncodingDeleteFhirResource(unittest.TestCase):
+    """delete_fhir_resource must pass the search param value via params= not URL concat."""
+
+    def setUp(self):
+        self.mock_session = Mock()
+        self.service = _make_service(self.mock_session)
+
+    def test_identifier_with_ampersand_uses_params(self):
+        get_response = Mock()
+        get_response.status_code = 200
+        get_response.json.return_value = {"entry": []}
+        self.mock_session.get.return_value = get_response
+
+        self.service.delete_fhir_resource("Specimen", "&:2022:118485")
+
+        _, kwargs = self.mock_session.get.call_args
+        params = kwargs.get("params", {})
+        self.assertEqual(params.get("identifier"), "&:2022:118485")
+        self.assertNotIn("&:2022:118485", kwargs.get("url", ""))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/util/metrics.py
+++ b/util/metrics.py
@@ -122,7 +122,8 @@ def update_fhir_resource_counts(blaze_url: str = None, miabis_blaze_url: str = N
     def fetch_count(base_url: str, resource_type: str) -> int:
         try:
             response = requests.get(
-                f"{base_url}/{resource_type}?_summary=count",
+                f"{base_url}/{resource_type}",
+                params={"_summary": "count"},
                 headers={"Accept": "application/fhir+json"},
                 timeout=10
             )


### PR DESCRIPTION
## Fhir module pull request:

### Description:
- replace the url concatenation for FHIR search with params
### Checklist:

_Make sure you tick all the boxes bellow if they are true or do not apply:_

- [x] I have performed a self-review of my code
- [x] My code follows [Google Python Style](https://google.github.io/styleguide/pyguide.html)
- [x] I have made my code as simple as possible
- [x] I have added unit tests and the code coverage has not decreased
- [x] I have updated the documentation in all relevant places
