### PR TITLE
fix: change default logging level from DEBUG to INFO

### DIFF
--- a/util/custom_logger.py
+++ b/util/custom_logger.py
@@ -59,7 +59,7 @@ def setup_logger():
     with open(config_path, 'r') as config_file:
         log_cfg = yaml.safe_load(config_file.read())
         if "root" in log_cfg:
-            log_cfg["root"]["level"] = os.getenv("LOG_LEVEL","DEBUG").upper()
+            log_cfg["root"]["level"] = os.getenv("LOG_LEVEL","INFO").upper()
 
         handlers_with_files = [h for h in log_cfg.get("handlers", {}).values() if "filename" in h]
         if handlers_with_files:

--- a/util/logging.yaml
+++ b/util/logging.yaml
@@ -32,11 +32,7 @@ handlers:
     formatter: simple
     stream: ext://sys.stdout
 root:
-  level: DEBUG
-  handlers: [console, app_file]
-
-default:
-  level: DEBUG
+  level: INFO
   handlers: [console, app_file]
 
 loggers:


### PR DESCRIPTION
## Fhir module pull request:
### Description:
 - changed logging level to INFO by default
 
### Checklist:
- [x] I have performed a self-review of my code
- [x] My code follows [Google Python Style](https://google.github.io/styleguide/pyguide.html)
- [x] I have made my code as simple as possible
- [x] I have added unit tests and the code coverage has not decreased
- [x] I have updated the documentation in all relevant places
