### PR TITLE
fix: emit FHIR-valid bbmri.de output (coding.system on diagnosis/storage, Organization.alias list)

### DIFF
--- a/model/sample.py
+++ b/model/sample.py
@@ -142,6 +142,8 @@ class Sample(SampleInterface):
         storage_temperature_extension.url = "https://fhir.bbmri.de/StructureDefinition/StorageTemperature"
         storage_temperature_extension.valueCodeableConcept = CodeableConcept()
         storage_temperature_extension.valueCodeableConcept.coding = [Coding()]
+        storage_temperature_extension.valueCodeableConcept.coding[0].system = \
+            "https://fhir.bbmri.de/CodeSystem/StorageTemperature"
         storage_temperature_extension.valueCodeableConcept.coding[0].code = self.storage_temperature.value
         return storage_temperature_extension
 
@@ -152,6 +154,7 @@ class Sample(SampleInterface):
             fhir_diagnosis.url = "https://fhir.bbmri.de/StructureDefinition/SampleDiagnosis"
             fhir_diagnosis.valueCodeableConcept = CodeableConcept()
             fhir_diagnosis.valueCodeableConcept.coding = [Coding()]
+            fhir_diagnosis.valueCodeableConcept.coding[0].system = "http://hl7.org/fhir/sid/icd-10"
             fhir_diagnosis.valueCodeableConcept.coding[0].code = self.__diagnosis_with_period(diagnosis)
             diagnoses_extensions.append(fhir_diagnosis)
         return diagnoses_extensions

--- a/model/sample_collection.py
+++ b/model/sample_collection.py
@@ -28,7 +28,7 @@ class SampleCollection(CollectionInterface):
         if self._name is not None:
             fhir_organization.name = self._name
         if self._acronym is not None:
-            fhir_organization.alias = self._acronym
+            fhir_organization.alias = [self._acronym]
         return fhir_organization
 
     def __create_fhir_identifier(self):

--- a/test/unit/model/test_sample.py
+++ b/test/unit/model/test_sample.py
@@ -31,6 +31,20 @@ class TestSample(unittest.TestCase):
         sample: Sample = Sample(identifier="sampleId", donor_id="patient")
         self.assertIsNone(sample.to_fhir().type)
 
+    def test_diagnosis_coding_has_icd10_system(self):
+        sample = Sample("sampleId", "patient", diagnoses=["C50"])
+        diagnosis_ext = [e for e in sample.to_fhir().extension
+                         if e.url == "https://fhir.bbmri.de/StructureDefinition/SampleDiagnosis"]
+        self.assertEqual("http://hl7.org/fhir/sid/icd-10",
+                         diagnosis_ext[0].valueCodeableConcept.coding[0].system)
+
+    def test_storage_temperature_coding_has_system(self):
+        sample = Sample("sampleId", "patient", storage_temperature=StorageTemperature.TEMPERATURE_LN)
+        temp_ext = [e for e in sample.to_fhir().extension
+                    if e.url == "https://fhir.bbmri.de/StructureDefinition/StorageTemperature"]
+        self.assertEqual("https://fhir.bbmri.de/CodeSystem/StorageTemperature",
+                         temp_ext[0].valueCodeableConcept.coding[0].system)
+
     def test_to_fhir_subject_ok(self):
         sample: Sample = Sample(identifier="sampleId", donor_id="patient")
         self.assertEqual("Patient/PatientFHIRId", sample.to_fhir(subject_id="PatientFHIRId").subject.reference)

--- a/test/unit/model/test_sample_collection.py
+++ b/test/unit/model/test_sample_collection.py
@@ -13,4 +13,6 @@ class TestSampleCollection(unittest.TestCase):
                                                                name="Test collection")
         self.assertEqual("test:collection:id", sample_collection.to_fhir().identifier[0].value)
         self.assertEqual("Test collection", sample_collection.to_fhir().name)
-        self.assertEqual("TC", sample_collection.to_fhir().alias)
+        # Organization.alias is 0..*; it must be a list so as_json() does not raise.
+        self.assertEqual(["TC"], sample_collection.to_fhir().alias)
+        self.assertEqual(["TC"], sample_collection.to_fhir().as_json()["alias"])


### PR DESCRIPTION
## Summary

Fixes the three bbmri.de-export defects reported in #86. Each made resources fail validation against `de.bbmri.fhir` (and one crashed on serialization).

## Changes

- **`SampleDiagnosis` coding had no `system`** (`model/sample.py`): the `SampleDiagnosis` extension slices `value[x].coding` on `system` (closed), and the `icd-10-who` slice fixes `system` to `http://hl7.org/fhir/sid/icd-10`. Without a system the coding matched no slice ("does not match any known slice"). Set that system — the same one `model/condition.py` already uses for `Condition.code`.
- **`StorageTemperature` coding had no `system`** (`model/sample.py`): the extension binds `value[x]` to `ValueSet/StorageTemperature` (required), so a system-less coding failed. Set `system = https://fhir.bbmri.de/CodeSystem/StorageTemperature`. (`Specimen.type` in the same file already sets its system — this just brings the two extension codings in line.)
- **`Organization.alias` assigned a `str`** (`model/sample_collection.py`): `alias` is `0..*`, so `Organization.as_json()` raised `FHIRValidationError` when an acronym was provided. Wrap in a list.

## Tests

- Added two coding-`system` tests in `test/unit/model/test_sample.py`.
- Updated `test/unit/model/test_sample_collection.py`: the previous assertion expected `alias == "TC"` (a `str`) and passed only because it never called `as_json()`; it now expects `["TC"]` and asserts `as_json()` succeeds.
- `make test`: **300 unit tests pass**.

## End-to-end

Building a bbmri.de bundle via the `model/` classes and validating against `de.bbmri.fhir#1.2.0` (validator 6.8.1, R4): the errors caused by these three defects are gone (the unknown-slice errors on `SampleDiagnosis`, the `StorageTemperature` required-binding failure, and the `alias` serialization crash).

Note: two unrelated findings remain and are **out of scope** here — a `Custodian` → `Collection` profile-match error (the collection Organization isn't stamped with the `Collection` profile in a standalone bundle; collections are provisioned separately in normal runs), and a residual `slicing-1` note on `SampleDiagnosis` that stems from the profile's `no-icd` slice lacking a `system` discriminator (surfaces under `-tx n/a`).

Closes #86.
